### PR TITLE
Add continuous fire while holding left click

### DIFF
--- a/public/gameScene.js
+++ b/public/gameScene.js
@@ -14,6 +14,15 @@ const BAR_WIDTH       = 40;
 const BAR_HEIGHT      = 5;
 const BAR_OFFSET_Y    = 28;
 
+// Mirrors WEAPONS[*].fireRate in config.js — only used to throttle client
+// 'shoot' sends while the mouse is held; the server remains authoritative.
+const RANGED_FIRE_RATE = {
+  gun: 400,
+  rifle: 150,
+  shotgun: 900,
+  sniper: 1200,
+};
+
 const LASER_CONFIG = {
   gun:     { length: 150, color: 0xff4444, alpha: 0.55, width: 1.5 },
   rifle:   { length: 280, color: 0xffff00, alpha: 0.65, width: 1.2 },
@@ -27,6 +36,8 @@ export class GameScene extends Phaser.Scene {
     super('Game');
     setGameScene(this);
     this.aimAngle = 0;
+    this.isFiring = false;
+    this._lastLocalShotAt = 0;
   }
 
   preload() {
@@ -113,7 +124,12 @@ export class GameScene extends Phaser.Scene {
       }
     });
 
-    this.input.on('pointerdown', this._onPointerDown, this);
+    this.input.on('pointerdown', pointer => {
+      if (!pointer.leftButtonDown() || !this.player) return;
+      this.isFiring = true;
+      this._fireCurrentWeapon();
+    });
+    this.input.on('pointerup', () => { this.isFiring = false; });
 
     const zombieDirs = [
       { key: 'zombie_down',  row: 0 },
@@ -164,9 +180,7 @@ export class GameScene extends Phaser.Scene {
     snd.play();
   }
 
-  _onPointerDown(pointer) {
-    if (!pointer.leftButtonDown() || !this.player) return;
-
+  _fireCurrentWeapon() {
     if (state.activeSlot === 'ranged') {
       socket.send(JSON.stringify({
         type: 'shoot', x: this.player.x, y: this.player.y, angle: this.aimAngle,
@@ -366,6 +380,15 @@ export class GameScene extends Phaser.Scene {
     this._drawLaser();
     this._drawAllHpBars();
     this.updateCamera();
+
+    if (this.isFiring && state.activeSlot === 'ranged') {
+      const weaponType = players[id]?.weaponType || 'gun';
+      const fireRate   = RANGED_FIRE_RATE[weaponType] || RANGED_FIRE_RATE.gun;
+      if (this.time.now - this._lastLocalShotAt >= fireRate) {
+        this._lastLocalShotAt = this.time.now;
+        this._fireCurrentWeapon();
+      }
+    }
   }
 
   spawnPlayer(playerId, playerColor, x = 100, y = 100, weaponType = 'gun') {


### PR DESCRIPTION
Closes #21.

Ranged weapons now keep firing at the weapon's fire rate while the left mouse button is held down, instead of requiring one click per shot.

## Changes
- Track pointer down/up state (`isFiring`) in `public/gameScene.js`.
- In the scene's `update()` loop, repeat the shot at the active ranged weapon's fire rate (mirrors `WEAPONS[*].fireRate` from `config.js`) while the button is held.
- Extracted the single-shot logic into `_fireCurrentWeapon()`, reused by both the initial click and the auto-repeat.
- Melee (knife) is untouched: still one swing per click.

Server-side rate limiting (`client.lastShotAt` / `fireRate` in `messageHandler.js`) was already in place and required no changes — it stays authoritative.

## Test plan
- [x] Started the server locally and drove the game with a headless Playwright browser: joined, held the mouse button down for 2s on the gun (fireRate 400ms) and confirmed 6 shots were sent (vs. 1 shot before this change) and zombies were killed automatically.
- [x] Verified pre-existing console pageerrors (`Cannot read properties of undefined (reading 'add')`) also occur on the unmodified code — unrelated to this change (likely headless-browser audio init), not introduced here.