### PR TITLE
Add magazine/ammo system with reload

### DIFF
--- a/config.js
+++ b/config.js
@@ -24,6 +24,8 @@ module.exports = {
       projectileLifetime: 1500,
       spread: 0.05,
       bulletsPerShot: 1,
+      magazineSize: 12,
+      reloadTime: 1200,
     },
     rifle: {
       name: 'rifle',
@@ -34,6 +36,8 @@ module.exports = {
       projectileLifetime: 2200,
       spread: 0.02,
       bulletsPerShot: 1,
+      magazineSize: 30,
+      reloadTime: 1800,
     },
     shotgun: {
       name: 'shotgun',
@@ -44,6 +48,8 @@ module.exports = {
       projectileLifetime: 700,
       spread: 0.15,
       bulletsPerShot: 6,
+      magazineSize: 6,
+      reloadTime: 2200,
     },
     sniper: {
       name: 'sniper',
@@ -54,6 +60,8 @@ module.exports = {
       projectileLifetime: 3000,
       spread: 0,
       bulletsPerShot: 1,
+      magazineSize: 5,
+      reloadTime: 2500,
     },
   },
 

--- a/gameLoop.js
+++ b/gameLoop.js
@@ -179,6 +179,8 @@ function startGameLoop() {
         if (distance(weapon, client) < WEAPON_PICKUP_RADIUS) {
           client.rangedWeapon = weapon.type;
           client.lastShotAt   = 0;
+          client.ammo         = WEAPONS[weapon.type].magazineSize;
+          client.reloading    = false;
           weaponsOnMap.delete(wId);
           broadcast({ type: 'weapon_remove', id: wId });
 
@@ -187,6 +189,9 @@ function startGameLoop() {
             rangedWeapon: client.rangedWeapon,
             meleeWeapon:  client.meleeWeapon,
             activeSlot:   client.activeSlot,
+          }));
+          ws.send(JSON.stringify({
+            type: 'ammo_update', ammo: client.ammo, magazineSize: WEAPONS[weapon.type].magazineSize, reloading: false,
           }));
           broadcast({
             type: 'player_slot',

--- a/messageHandler.js
+++ b/messageHandler.js
@@ -4,6 +4,28 @@ const { randomPosition, broadcast, getTopPlayers } = require('./utils');
 const { WEAPONS, MELEE, PLAYER_MAX_HP } = require('./config');
 const log = require('./logger');
 
+// Unlimited magazines, limited bullets per magazine: refills client.ammo to
+// the current weapon's magazineSize after reloadTime. Guards against the
+// client switching weapons or disconnecting mid-reload.
+function startReload(client, ws) {
+  const weaponName = client.rangedWeapon;
+  const weaponDef  = WEAPONS[weaponName] || WEAPONS['gun'];
+
+  client.reloading = true;
+  ws.send(JSON.stringify({
+    type: 'ammo_update', ammo: client.ammo ?? 0, magazineSize: weaponDef.magazineSize, reloading: true,
+  }));
+
+  setTimeout(() => {
+    if (!clients.has(ws) || client.rangedWeapon !== weaponName) return;
+    client.reloading = false;
+    client.ammo = weaponDef.magazineSize;
+    ws.send(JSON.stringify({
+      type: 'ammo_update', ammo: client.ammo, magazineSize: weaponDef.magazineSize, reloading: false,
+    }));
+  }, weaponDef.reloadTime);
+}
+
 function handleMessage(ws, data) {
   const msg = JSON.parse(data);
   const client = clients.get(ws);
@@ -17,6 +39,8 @@ function handleMessage(ws, data) {
     client.rangedWeapon = 'gun';
     client.meleeWeapon  = 'knife';
     client.activeSlot   = 'ranged';
+    client.ammo         = WEAPONS[client.rangedWeapon].magazineSize;
+    client.reloading    = false;
 
     scores.set(client.id, { zombiesKilled: 0, playersKilled: 0 });
 
@@ -29,6 +53,9 @@ function handleMessage(ws, data) {
       activeSlot:   client.activeSlot,
     }));
     ws.send(JSON.stringify({ type: 'hp_update', id: client.id, hp: client.hp, maxHp: PLAYER_MAX_HP }));
+    ws.send(JSON.stringify({
+      type: 'ammo_update', ammo: client.ammo, magazineSize: WEAPONS[client.rangedWeapon].magazineSize, reloading: false,
+    }));
 
     for (const wall of walls.values()) {
       ws.send(JSON.stringify({ type: 'wall_spawn', id: wall.id, x: wall.x, y: wall.y }));
@@ -71,12 +98,32 @@ function handleMessage(ws, data) {
     });
   }
 
+  // ---------- Rechargement manuel (arme à distance) ----------
+  if (msg.type === 'reload' && client.pseudo && client.activeSlot === 'ranged') {
+    const weaponDef = WEAPONS[client.rangedWeapon] || WEAPONS['gun'];
+    if (client.reloading) return;
+    if ((client.ammo ?? weaponDef.magazineSize) >= weaponDef.magazineSize) return;
+    startReload(client, ws);
+  }
+
   // ---------- Tir (arme à distance) ----------
   if (msg.type === 'shoot' && client.pseudo && client.activeSlot === 'ranged') {
     const weaponDef = WEAPONS[client.rangedWeapon] || WEAPONS['gun'];
+
+    if (client.reloading) return;
+    if ((client.ammo ?? weaponDef.magazineSize) <= 0) {
+      startReload(client, ws);
+      return;
+    }
+
     const now = Date.now();
     if (now - client.lastShotAt < weaponDef.fireRate) return;
     client.lastShotAt = now;
+    client.ammo -= 1;
+
+    ws.send(JSON.stringify({
+      type: 'ammo_update', ammo: client.ammo, magazineSize: weaponDef.magazineSize, reloading: false,
+    }));
 
     for (let i = 0; i < weaponDef.bulletsPerShot; i++) {
       const spreadOffset = (Math.random() - 0.5) * 2 * weaponDef.spread;

--- a/public/gameScene.js
+++ b/public/gameScene.js
@@ -115,6 +115,12 @@ export class GameScene extends Phaser.Scene {
       socket.send(JSON.stringify({ type: 'switch_slot' }));
     });
 
+    // R → recharger l'arme à distance
+    this.input.keyboard.on('keydown-R', () => {
+      if (!pseudo || state.activeSlot !== 'ranged') return;
+      socket.send(JSON.stringify({ type: 'reload' }));
+    });
+
     this.input.on('pointermove', pointer => {
       const wp = this.cameras.main.getWorldPoint(pointer.x, pointer.y);
       this.sight.setPosition(wp.x, wp.y);
@@ -318,6 +324,13 @@ export class GameScene extends Phaser.Scene {
         hud.style.color = pct > 60 ? '#44ff44' : pct > 30 ? '#ffaa00' : '#ff2222';
       }
     }
+  }
+
+  updateAmmo(ammo, magazineSize, reloading) {
+    const hud = document.getElementById('ammo-display');
+    if (!hud) return;
+    hud.innerText = reloading ? '⏳ RELOADING…' : `🔫 ${ammo} / ${magazineSize}`;
+    hud.style.color = reloading ? '#ffaa00' : (ammo === 0 ? '#ff2222' : '#ffcc44');
   }
 
   onSlotsUpdate(data) {

--- a/public/index.html
+++ b/public/index.html
@@ -219,6 +219,19 @@
       text-shadow:0 0 6px #44ff4488;
     }
 
+    /* Ammo HUD */
+    #ammo-hud {
+      display:flex; align-items:center;
+      margin-top:4px; padding:4px 8px;
+      background:#1a1400; border:1px solid #4a3a00;
+      clip-path: polygon(0 0,96% 0,100% 30%,100% 100%,4% 100%,0 70%);
+    }
+    #ammo-display {
+      font-size:11px; color:#ffcc44;
+      letter-spacing:2px;
+      text-shadow:0 0 6px #ffcc4488;
+    }
+
     /* Scoreboard */
     #scoreboard { flex-shrink:0; }
 
@@ -348,6 +361,9 @@
           </div>
           <div id="hp-hud">
             <span id="hp-display">❤ 100 / 100</span>
+          </div>
+          <div id="ammo-hud">
+            <span id="ammo-display">🔫 12 / 12</span>
           </div>
         </div>
       </div>

--- a/public/socketHandler.js
+++ b/public/socketHandler.js
@@ -51,6 +51,10 @@ socket.addEventListener('message', (event) => {
     state.gameScene.updateHp(data.id, data.hp, data.maxHp);
   }
 
+  if (data.type === 'ammo_update' && state.gameScene) {
+    state.gameScene.updateAmmo(data.ammo, data.magazineSize, data.reloading);
+  }
+
   // Mise à jour des slots du joueur local
   if (data.type === 'slots_update') {
     state.setRangedWeapon(data.rangedWeapon);
@@ -115,4 +119,7 @@ function updateSlotsHUD(data) {
 
   slot1El.classList.toggle('slot-active', data.activeSlot === 'ranged');
   slot2El.classList.toggle('slot-active', data.activeSlot === 'melee');
+
+  const ammoHud = document.getElementById('ammo-hud');
+  if (ammoHud) ammoHud.style.display = data.activeSlot === 'ranged' ? 'flex' : 'none';
 }


### PR DESCRIPTION
Closes #22.

Ranged weapons now have a limited magazine size and must reload once empty. Magazines are unlimited — reloading always succeeds, it just takes time.

## Changes
- `config.js`: added `magazineSize` and `reloadTime` per ranged weapon (gun 12/1200ms, rifle 30/1800ms, shotgun 6/2200ms, sniper 5/2500ms).
- `messageHandler.js`: server tracks `client.ammo` / `client.reloading`. Each `shoot` decrements ammo by 1; an empty magazine auto-triggers a reload. New `reload` message type supports a manual/tactical reload (e.g. R key) even before the mag is empty. A `startReload()` helper refills to the weapon's magazine size after `reloadTime`, guarding against the client switching weapons or disconnecting mid-reload.
- `gameLoop.js`: picking up a new weapon resets ammo to that weapon's full magazine and cancels any in-progress reload.
- Client (`public/gameScene.js`, `socketHandler.js`, `index.html`): new ammo HUD (`#ammo-hud`) showing `ammo / magazineSize` or a reloading indicator, hidden while the melee slot is active; **R** sends a reload request.

Melee (knife) is unaffected — no ammo concept there.

## Test plan
- [x] Ran the server locally and drove the game with headless Playwright, capturing the raw `ammo_update` websocket frames.
- [x] Held fire on the gun (magazine 12, fire rate 400ms): observed ammo counting down 11→0, then `reloading: true`, then ammo restored to 12 and firing resumed — confirms auto-reload on empty magazine and unlimited magazines.
- [x] Fired a few shots then pressed **R**: observed a manual/tactical reload cycle (`reloading: true` → ammo back to full) without needing to empty the magazine first.
- [x] Confirmed pre-existing headless-browser console `pageerror`s are unrelated to this change (also present on unmodified code).