### PR TITLE
Improve zombie AI

### DIFF
--- a/config.js
+++ b/config.js
@@ -7,6 +7,8 @@ module.exports = {
   ZOMBIE_SPAWN_INTERVAL: 5,
   ZOMBIE_RADIUS: 18,
   ZOMBIE_DAMAGE: 34,         // dégâts par contact (cooldown 1s)
+  ZOMBIE_DECISION_INTERVAL: 500, // ms between target/pathfinding re-evaluation
+  ZOMBIE_TARGET_SWITCH_MARGIN: 40, // px a new target must be closer by to steal aggro
 
   PLAYER_MAX_HP: 100,
 

--- a/gameLoop.js
+++ b/gameLoop.js
@@ -9,29 +9,22 @@ const {
   ZOMBIE_SPEED,
   ZOMBIE_SPAWN_INTERVAL,
   ZOMBIE_DAMAGE,
+  ZOMBIE_DECISION_INTERVAL,
+  ZOMBIE_TARGET_SWITCH_MARGIN,
   WEAPON_SPAWN_INTERVAL,
   MAX_WEAPONS_ON_MAP,
   PLAYER_MAX_HP,
   WEAPONS,
 } = require('./config');
 const { generateBuildings } = require('./buildingLoader');
+const { wallCollision, buildGrid, worldToCell, findPath, hasLineOfSight } = require('./zombieAI');
 
-const WALL_SIZE = 64;
 const WEAPON_TYPES = Object.keys(WEAPONS);
 const WEAPON_PICKUP_RADIUS = 25;
 
 // Dimensions du monde — à ajuster selon votre config
 const WORLD_W = 2000;
 const WORLD_H = 2000;
-
-function wallCollision(obj, wall) {
-  return (
-    obj.x > wall.x - WALL_SIZE / 2 &&
-    obj.x < wall.x + WALL_SIZE / 2 &&
-    obj.y > wall.y - WALL_SIZE / 2 &&
-    obj.y < wall.y + WALL_SIZE / 2
-  );
-}
 
 function respawnClient(client) {
   const newPos = randomPosition();
@@ -53,11 +46,24 @@ function startGameLoop() {
   // pensez aussi à les envoyer dans votre handler 'join' via ws.send)
   broadcast({ type: 'walls_init', walls: buildingWalls });
 
+  // Occupancy grid used for zombie pathfinding around buildings
+  const pathGrid = buildGrid(buildingWalls, WORLD_W, WORLD_H);
+
+  // Picks a random position that doesn't land inside a wall cell
+  function randomOpenPosition(maxAttempts = 20) {
+    for (let i = 0; i < maxAttempts; i++) {
+      const pos  = randomPosition();
+      const cell = worldToCell(pos);
+      if (!pathGrid.grid[cell.row]?.[cell.col]) return pos;
+    }
+    return randomPosition();
+  }
+
   // Spawn zombies
   setInterval(() => {
     const id     = 'z-' + randomUUID();
-    const pos    = randomPosition();
-    const zombie = { id, x: pos.x, y: pos.y, targetId: null };
+    const pos    = randomOpenPosition();
+    const zombie = { id, x: pos.x, y: pos.y, targetId: null, path: [], nextDecisionAt: 0 };
     zombies.set(id, zombie);
     broadcast({ type: 'zombie_spawn', id: zombie.id, x: zombie.x, y: zombie.y });
   }, ZOMBIE_SPAWN_INTERVAL * 1000);
@@ -126,21 +132,47 @@ function startGameLoop() {
 
     // --- Zombies ---
     for (const zombie of zombies.values()) {
-      if (!zombie.targetId || ![...clients.values()].find(c => c.id === zombie.targetId)) {
+      let target = zombie.targetId
+        ? [...clients.values()].find(c => c.id === zombie.targetId)
+        : null;
+
+      // Re-evaluate target and path on a timer instead of every tick (cheaper, steadier movement)
+      if (now >= zombie.nextDecisionAt) {
+        zombie.nextDecisionAt = now + ZOMBIE_DECISION_INTERVAL + Math.random() * 200;
+
         let closest = null, minDist = Infinity;
         for (const client of clients.values()) {
           if (!client.pseudo) continue;
           const d = distance(zombie, client);
-          if (d < minDist) { minDist = d; closest = client.id; }
+          if (d < minDist) { minDist = d; closest = client; }
         }
-        zombie.targetId = closest;
+
+        const currentDist = target ? distance(zombie, target) : Infinity;
+        if (closest && minDist < currentDist - ZOMBIE_TARGET_SWITCH_MARGIN) target = closest;
+
+        zombie.targetId = target ? target.id : null;
+        zombie.path = [];
+
+        if (target && !hasLineOfSight(walls.values(), zombie, target)) {
+          const path = findPath(pathGrid, worldToCell(zombie), worldToCell(target));
+          zombie.path = path || []; // null (unreachable) falls back to a straight chase below
+        }
       }
 
-      const target = [...clients.values()].find(c => c.id === zombie.targetId);
       if (!target) continue;
 
-      const dx  = target.x - zombie.x;
-      const dy  = target.y - zombie.y;
+      // Follow the computed path around obstacles, or go straight when there's a clear line of sight
+      let moveTarget = target;
+      if (zombie.path.length > 0) {
+        moveTarget = zombie.path[0];
+        if (distance(zombie, moveTarget) < ZOMBIE_SPEED / 60 + 4) {
+          zombie.path.shift();
+          moveTarget = zombie.path[0] || target;
+        }
+      }
+
+      const dx  = moveTarget.x - zombie.x;
+      const dy  = moveTarget.y - zombie.y;
       const len = Math.sqrt(dx * dx + dy * dy);
 
       if (len > 0) {

--- a/zombieAI.js
+++ b/zombieAI.js
@@ -1,0 +1,98 @@
+const WALL_SIZE = 64;
+
+// Checks if a point collides with a single wall's bounding box
+function wallCollision(obj, wall) {
+  return (
+    obj.x > wall.x - WALL_SIZE / 2 &&
+    obj.x < wall.x + WALL_SIZE / 2 &&
+    obj.y > wall.y - WALL_SIZE / 2 &&
+    obj.y < wall.y + WALL_SIZE / 2
+  );
+}
+
+// Builds a boolean occupancy grid from the wall list (one cell per WALL_SIZE)
+function buildGrid(wallList, worldW, worldH) {
+  const cols = Math.ceil(worldW / WALL_SIZE);
+  const rows = Math.ceil(worldH / WALL_SIZE);
+  const grid = Array.from({ length: rows }, () => new Array(cols).fill(false));
+
+  for (const wall of wallList) {
+    const col = Math.floor(wall.x / WALL_SIZE);
+    const row = Math.floor(wall.y / WALL_SIZE);
+    if (row >= 0 && row < rows && col >= 0 && col < cols) grid[row][col] = true;
+  }
+
+  return { grid, cols, rows };
+}
+
+function worldToCell(pos) {
+  return { row: Math.floor(pos.y / WALL_SIZE), col: Math.floor(pos.x / WALL_SIZE) };
+}
+
+function cellCenter(cell) {
+  return { x: cell.col * WALL_SIZE + WALL_SIZE / 2, y: cell.row * WALL_SIZE + WALL_SIZE / 2 };
+}
+
+const DIRECTIONS = [
+  [-1, 0], [1, 0], [0, -1], [0, 1],
+  [-1, -1], [-1, 1], [1, -1], [1, 1],
+];
+
+// BFS on the occupancy grid (uniform cost -> shortest path in cell count).
+// Returns a list of world-space waypoints, or null if unreachable.
+function findPath(gridInfo, startCell, endCell) {
+  const { grid, cols, rows } = gridInfo;
+  if (grid[endCell.row]?.[endCell.col]) return null;
+  if (startCell.row === endCell.row && startCell.col === endCell.col) return [];
+
+  const key = (r, c) => r * cols + c;
+  const visited = new Set([key(startCell.row, startCell.col)]);
+  const cameFrom = new Map();
+  const queue = [startCell];
+  let head = 0;
+
+  while (head < queue.length) {
+    const { row, col } = queue[head++];
+    if (row === endCell.row && col === endCell.col) break;
+
+    for (const [dr, dc] of DIRECTIONS) {
+      const nr = row + dr, nc = col + dc;
+      if (nr < 0 || nr >= rows || nc < 0 || nc >= cols || grid[nr][nc]) continue;
+      if (dr !== 0 && dc !== 0 && (grid[row][nc] || grid[nr][col])) continue; // no cutting through corners
+      const k = key(nr, nc);
+      if (visited.has(k)) continue;
+      visited.add(k);
+      cameFrom.set(k, { row, col });
+      queue.push({ row: nr, col: nc });
+    }
+  }
+
+  if (!visited.has(key(endCell.row, endCell.col))) return null;
+
+  const path = [];
+  let cur = endCell;
+  while (cur.row !== startCell.row || cur.col !== startCell.col) {
+    path.push(cur);
+    cur = cameFrom.get(key(cur.row, cur.col));
+  }
+  path.reverse();
+  return path.map(cellCenter);
+}
+
+// Samples points along the segment to detect whether a wall blocks a direct path
+function hasLineOfSight(wallList, from, to) {
+  const dx = to.x - from.x;
+  const dy = to.y - from.y;
+  const dist = Math.sqrt(dx * dx + dy * dy);
+  const steps = Math.max(1, Math.ceil(dist / (WALL_SIZE / 2)));
+
+  for (let i = 1; i < steps; i++) {
+    const point = { x: from.x + (dx * i) / steps, y: from.y + (dy * i) / steps };
+    for (const wall of wallList) {
+      if (wallCollision(point, wall)) return false;
+    }
+  }
+  return true;
+}
+
+module.exports = { WALL_SIZE, wallCollision, buildGrid, worldToCell, cellCenter, findPath, hasLineOfSight };


### PR DESCRIPTION
Closes #23

- Zombies pathfind around buildings (grid-based BFS) when they lack line of sight to their target, instead of sliding along walls and getting stuck.
- Target selection re-evaluates periodically and only switches to a meaningfully closer player.
- Zombie spawn now avoids wall cells, fixing zombies trapped inside buildings that could still deal contact damage.