### PR TITLE
Add HP bar for monsters and players

### DIFF
--- a/config.js
+++ b/config.js
@@ -9,6 +9,7 @@ module.exports = {
   ZOMBIE_DAMAGE: 34,         // dégâts par contact (cooldown 1s)
   ZOMBIE_DECISION_INTERVAL: 500, // ms between target/pathfinding re-evaluation
   ZOMBIE_TARGET_SWITCH_MARGIN: 40, // px a new target must be closer by to steal aggro
+  ZOMBIE_MAX_HP: 50,
 
   PLAYER_MAX_HP: 100,
 

--- a/gameLoop.js
+++ b/gameLoop.js
@@ -11,6 +11,7 @@ const {
   ZOMBIE_DAMAGE,
   ZOMBIE_DECISION_INTERVAL,
   ZOMBIE_TARGET_SWITCH_MARGIN,
+  ZOMBIE_MAX_HP,
   WEAPON_SPAWN_INTERVAL,
   MAX_WEAPONS_ON_MAP,
   PLAYER_MAX_HP,
@@ -63,9 +64,12 @@ function startGameLoop() {
   setInterval(() => {
     const id     = 'z-' + randomUUID();
     const pos    = randomOpenPosition();
-    const zombie = { id, x: pos.x, y: pos.y, targetId: null, path: [], nextDecisionAt: 0 };
+    const zombie = {
+      id, x: pos.x, y: pos.y, targetId: null, path: [], nextDecisionAt: 0,
+      hp: ZOMBIE_MAX_HP, maxHp: ZOMBIE_MAX_HP,
+    };
     zombies.set(id, zombie);
-    broadcast({ type: 'zombie_spawn', id: zombie.id, x: zombie.x, y: zombie.y });
+    broadcast({ type: 'zombie_spawn', id: zombie.id, x: zombie.x, y: zombie.y, hp: zombie.hp, maxHp: zombie.maxHp });
   }, ZOMBIE_SPAWN_INTERVAL * 1000);
 
   // Spawn armes au sol
@@ -114,12 +118,16 @@ function startGameLoop() {
 
       for (const [zId, zombie] of zombies) {
         if (distance(proj, zombie) < ZOMBIE_RADIUS + PROJECTILE_RADIUS) {
-          zombies.delete(zId);
-          const ks = scores.get(proj.from) || { zombiesKilled: 0, playersKilled: 0 };
-          ks.zombiesKilled += 1;
-          scores.set(proj.from, ks);
-          broadcast({ type: 'score_update', playerId: proj.from, ...ks, topPlayers: getTopPlayers() });
-          broadcast({ type: 'zombie_remove', id: zId });
+          zombie.hp = (zombie.hp ?? ZOMBIE_MAX_HP) - (proj.damage || 30);
+          broadcast({ type: 'zombie_hp_update', id: zId, hp: zombie.hp, maxHp: zombie.maxHp });
+          if (zombie.hp <= 0) {
+            zombies.delete(zId);
+            const ks = scores.get(proj.from) || { zombiesKilled: 0, playersKilled: 0 };
+            ks.zombiesKilled += 1;
+            scores.set(proj.from, ks);
+            broadcast({ type: 'score_update', playerId: proj.from, ...ks, topPlayers: getTopPlayers() });
+            broadcast({ type: 'zombie_remove', id: zId });
+          }
           collided = true; break;
         }
       }

--- a/messageHandler.js
+++ b/messageHandler.js
@@ -1,7 +1,7 @@
 const { randomUUID } = require('crypto');
 const { clients, projectiles, scores, walls, zombies } = require('./state');
 const { randomPosition, broadcast, getTopPlayers } = require('./utils');
-const { WEAPONS, MELEE, PLAYER_MAX_HP } = require('./config');
+const { WEAPONS, MELEE, PLAYER_MAX_HP, ZOMBIE_MAX_HP } = require('./config');
 const log = require('./logger');
 
 // Unlimited magazines, limited bullets per magazine: refills client.ammo to
@@ -187,14 +187,19 @@ function handleMessage(ws, data) {
       }
 
       // --- Zombie touché ---
-      if (zombies.has(targetId)) {
-        zombies.delete(targetId);
-        log.debug(`killed zombie ${targetId}`);
-        const ks = scores.get(client.id) || { zombiesKilled: 0, playersKilled: 0 };
-        ks.zombiesKilled += 1;
-        scores.set(client.id, ks);
-        broadcast({ type: 'score_update', playerId: client.id, ...ks, topPlayers: getTopPlayers() });
-        broadcast({ type: 'zombie_remove', id: targetId });
+      const targetZombie = zombies.get(targetId);
+      if (targetZombie) {
+        targetZombie.hp = (targetZombie.hp ?? ZOMBIE_MAX_HP) - meleeDef.damage;
+        broadcast({ type: 'zombie_hp_update', id: targetId, hp: targetZombie.hp, maxHp: targetZombie.maxHp });
+        if (targetZombie.hp <= 0) {
+          zombies.delete(targetId);
+          log.debug(`killed zombie ${targetId}`);
+          const ks = scores.get(client.id) || { zombiesKilled: 0, playersKilled: 0 };
+          ks.zombiesKilled += 1;
+          scores.set(client.id, ks);
+          broadcast({ type: 'score_update', playerId: client.id, ...ks, topPlayers: getTopPlayers() });
+          broadcast({ type: 'zombie_remove', id: targetId });
+        }
       }
     }
 

--- a/public/gameScene.js
+++ b/public/gameScene.js
@@ -10,6 +10,7 @@ const WEAPON_OFFSET_X = 0;
 const WEAPON_OFFSET_Y = 0;
 const KNIFE_RANGE     = 180;
 const PLAYER_MAX_HP   = 100;
+const ZOMBIE_MAX_HP   = 50; // fallback, server sends the authoritative value on spawn
 const BAR_WIDTH       = 40;
 const BAR_HEIGHT      = 5;
 const BAR_OFFSET_Y    = 28;
@@ -208,11 +209,11 @@ export class GameScene extends Phaser.Scene {
       if (d <= KNIFE_RANGE) hitIds.push(pid);
     }
 
-    for (const [zid, zombieSprite] of Object.entries(zombies)) {
-      if (!zombieSprite) continue;
+    for (const [zid, entry] of Object.entries(zombies)) {
+      if (!entry?.sprite) continue;
       const d = Phaser.Math.Distance.Between(
         this.player.x, this.player.y,
-        zombieSprite.x, zombieSprite.y
+        entry.sprite.x, entry.sprite.y
       );
       if (d <= KNIFE_RANGE) hitIds.push(zid);
     }
@@ -291,23 +292,29 @@ export class GameScene extends Phaser.Scene {
     this.laserGraphics.fillCircle(ex, ey, cfg.width * 2);
   }
 
+  _drawHpBar(sprite, hp, maxHp) {
+    const ratio = Phaser.Math.Clamp(hp / maxHp, 0, 1);
+    const sx    = sprite.x - BAR_WIDTH / 2;
+    const sy    = sprite.y - BAR_OFFSET_Y;
+
+    this.hpGraphics.fillStyle(0x222222, 0.75);
+    this.hpGraphics.fillRect(sx, sy, BAR_WIDTH, BAR_HEIGHT);
+    const barColor = ratio > 0.6 ? 0x44ff44 : ratio > 0.3 ? 0xffaa00 : 0xff2222;
+    this.hpGraphics.fillStyle(barColor, 1);
+    this.hpGraphics.fillRect(sx, sy, BAR_WIDTH * ratio, BAR_HEIGHT);
+    this.hpGraphics.lineStyle(1, 0x000000, 0.6);
+    this.hpGraphics.strokeRect(sx, sy, BAR_WIDTH, BAR_HEIGHT);
+  }
+
   _drawAllHpBars() {
     this.hpGraphics.clear();
     for (const entry of Object.values(players)) {
       if (!entry?.sprite) continue;
-      const hp    = entry.hp    ?? PLAYER_MAX_HP;
-      const maxHp = entry.maxHp ?? PLAYER_MAX_HP;
-      const ratio = Phaser.Math.Clamp(hp / maxHp, 0, 1);
-      const sx    = entry.sprite.x - BAR_WIDTH / 2;
-      const sy    = entry.sprite.y - BAR_OFFSET_Y;
-
-      this.hpGraphics.fillStyle(0x222222, 0.75);
-      this.hpGraphics.fillRect(sx, sy, BAR_WIDTH, BAR_HEIGHT);
-      const barColor = ratio > 0.6 ? 0x44ff44 : ratio > 0.3 ? 0xffaa00 : 0xff2222;
-      this.hpGraphics.fillStyle(barColor, 1);
-      this.hpGraphics.fillRect(sx, sy, BAR_WIDTH * ratio, BAR_HEIGHT);
-      this.hpGraphics.lineStyle(1, 0x000000, 0.6);
-      this.hpGraphics.strokeRect(sx, sy, BAR_WIDTH, BAR_HEIGHT);
+      this._drawHpBar(entry.sprite, entry.hp ?? PLAYER_MAX_HP, entry.maxHp ?? PLAYER_MAX_HP);
+    }
+    for (const entry of Object.values(zombies)) {
+      if (!entry?.sprite) continue;
+      this._drawHpBar(entry.sprite, entry.hp ?? ZOMBIE_MAX_HP, entry.maxHp ?? ZOMBIE_MAX_HP);
     }
   }
 
@@ -495,28 +502,29 @@ export class GameScene extends Phaser.Scene {
     if (this.wallGroup) this.physics.add.overlap(bullet, this.wallGroup, () => bullet.destroy());
   }
 
-  spawnZombie(zombieId, x, y) {
+  spawnZombie(zombieId, x, y, hp = ZOMBIE_MAX_HP, maxHp = ZOMBIE_MAX_HP) {
     if (zombies[zombieId]) return;
-    const zombie = this.physics.add.sprite(x, y, 'zombie');
-    zombie.setDepth(4);
-    zombie.setScale(2);
-    zombie.play('zombie_down');
+    const sprite = this.physics.add.sprite(x, y, 'zombie');
+    sprite.setDepth(4);
+    sprite.setScale(2);
+    sprite.play('zombie_down');
 
     // Son d'apparition zombie (un sur deux pour éviter la saturation)
     if (Math.random() < 0.5) {
       if (!this.sounds.zombie.isPlaying) this.sounds.zombie.play();
     }
 
-    zombies[zombieId] = zombie;
+    zombies[zombieId] = { sprite, hp, maxHp };
   }
 
   updateZombie(zombieId, x, y) {
-    const zombie = zombies[zombieId];
-    if (!zombie) return;
+    const entry = zombies[zombieId];
+    if (!entry) return;
+    const sprite = entry.sprite;
 
-    const prevX = zombie.x;
-    const prevY = zombie.y;
-    zombie.setPosition(x, y);
+    const prevX = sprite.x;
+    const prevY = sprite.y;
+    sprite.setPosition(x, y);
 
     const dx = x - prevX;
     const dy = y - prevY;
@@ -528,12 +536,19 @@ export class GameScene extends Phaser.Scene {
     } else {
       anim = dy > 0 ? 'zombie_down' : 'zombie_up';
     }
-    if (zombie.anims.currentAnim?.key !== anim) zombie.play(anim);
+    if (sprite.anims.currentAnim?.key !== anim) sprite.play(anim);
+  }
+
+  updateZombieHp(zombieId, hp, maxHp) {
+    const entry = zombies[zombieId];
+    if (!entry) return;
+    entry.hp    = hp;
+    entry.maxHp = maxHp;
   }
 
   removeZombie(zombieId) {
-    const zombie = zombies[zombieId];
-    if (zombie) { zombie.destroy(); delete zombies[zombieId]; }
+    const entry = zombies[zombieId];
+    if (entry) { entry.sprite.destroy(); delete zombies[zombieId]; }
   }
 
   spawnWeaponOnMap(weaponId, x, y, weaponType) {

--- a/public/socketHandler.js
+++ b/public/socketHandler.js
@@ -75,10 +75,13 @@ socket.addEventListener('message', (event) => {
   }
 
   if (data.type === 'zombie_spawn' && state.gameScene) {
-    state.gameScene.spawnZombie(data.id, data.x, data.y);
+    state.gameScene.spawnZombie(data.id, data.x, data.y, data.hp, data.maxHp);
   }
   if (data.type === 'zombie_move' && state.gameScene) {
     state.gameScene.updateZombie(data.id, data.x, data.y);
+  }
+  if (data.type === 'zombie_hp_update' && state.gameScene) {
+    state.gameScene.updateZombieHp(data.id, data.hp, data.maxHp);
   }
   if (data.type === 'zombie_remove' && state.gameScene) {
     state.gameScene.removeZombie(data.id);


### PR DESCRIPTION
Closes #24

- Zombies now have real HP instead of dying in one hit; projectiles and melee hits damage them and broadcast zombie_hp_update, removing them once HP reaches 0.
- Client-side zombie entries hold { sprite, hp, maxHp } like players do, reusing the existing HP bar rendering to draw a bar above every zombie.